### PR TITLE
4.29-4.39 Add commands

### DIFF
--- a/sym/symbols.json
+++ b/sym/symbols.json
@@ -84,8 +84,8 @@
 
     "dot":
     {"output":{
-        "latex":"\\dot{$1}",
-        "asciimath":"dot {$1}"},
+        "latex":"\\dot{{$1}}",
+        "asciimath":"dot {{$1}}"},
      "attrs":{
 	 "type":"dot",
 	 "group":"functions"},
@@ -107,8 +107,8 @@
 
     "underline":
     {"output":{
-        "latex":"\\underline{$1}",
-        "asciimath":"underline {$1}"},
+        "latex":"\\underline{{$1}}",
+        "asciimath":"underline {{$1}}"},
      "attrs":{
 	 "type":"underline",
 	 "group":"functions"},
@@ -116,10 +116,35 @@
 	 {"delete":"1"}]
     },
 
+
+    "bold":
+    {"output":{
+        "latex":"\\mathbf{{$1}}",
+        "asciimath":"mathbf {{$1}}"},
+     "attrs":{
+	 "type":"mathbf",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+
+    "mathcal":
+    {"output":{
+        "latex":"\\mathcal{{$1}}",
+        "asciimath":"mathcal {{$1}}"},
+     "attrs":{
+	 "type":"mathcal",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+
     "hat":
     {"output":{
-        "latex":"\\hat{$1}",
-        "asciimath":"hat {$1}"},
+        "latex":"\\hat{{$1}}",
+        "asciimath":"hat {{$1}}"},
      "attrs":{
 	 "type":"hat",
 	 "group":"functions"},

--- a/sym/symbols.json
+++ b/sym/symbols.json
@@ -95,8 +95,8 @@
 
     "dagger":
     {"output":{
-        "latex":"{$1}\\dagger",
-        "asciimath":"{$1} dagger"},
+        "latex":"{$1}^{\\dagger}",
+        "asciimath":"{$1}^ {dagger}"},
      "attrs":{
 	 "type":"dagger",
 	 "group":"functions"},
@@ -129,7 +129,7 @@
     },
 
 
-    "mathcal":
+    "cal":
     {"output":{
         "latex":"\\mathcal{{$1}}",
         "asciimath":"mathcal {{$1}}"},
@@ -152,6 +152,17 @@
 	 {"delete":"1"}]
     },
 
+    "widehat":
+    {"output":{
+        "latex":"\\widehat{{$1}}",
+        "asciimath":"widehat {{$1}}"},
+     "attrs":{
+	 "type":"widehat",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
     "tvec":
     {"output":{
         "latex":"\\vec{$1}",
@@ -165,7 +176,7 @@
 
     "ceil":
     {"output":{
-        "latex":"\\lceil{$1}\\rceil",
+        "latex":"\\left\\lceil{$1}\\right\\rceil",
 	"asciimath":"⌈{$1}⌉"},
      "attrs":{
 	 "type":"bracket",

--- a/sym/symbols.json
+++ b/sym/symbols.json
@@ -24,17 +24,6 @@
      ]
     },
 
-    "text":
-    {"output":{
-        "latex":"\\text{{$1}}",
-        "asciimath":"text({$1})"},
-     "attrs":{
-	 "type":"text",
-	 "group":"editor"},
-     "args":[
-	 {"mode":"text"}]
-    },
-
     "sym_name":
     {"output":{
         "latex":"\\backslash\\texttt{{$1}}",
@@ -104,6 +93,17 @@
 	 {"delete":"1"}]
     },
 
+    "prime":
+    {"output":{
+        "latex":"{$1}^{\\prime}",
+        "asciimath":"{$1}^ {prime}"},
+     "attrs":{
+	 "type":"prime",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
 
     "underline":
     {"output":{
@@ -135,6 +135,17 @@
         "asciimath":"mathcal {{$1}}"},
      "attrs":{
 	 "type":"mathcal",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+    "text":
+    {"output":{
+        "latex":"\\text{{$1}}",
+        "asciimath":"text {{$1}}"},
+     "attrs":{
+	 "type":"text",
 	 "group":"functions"},
      "args":[
 	 {"delete":"1"}]
@@ -270,6 +281,21 @@
      "args":[
 	 {"up":"1","down":"2","name":"numerator"},
 	 {"up":"1","down":"2","delete":"1","name":"denominator"}
+     ]
+    },
+
+    "oint":
+    {"output":{
+        "latex":"\\displaystyle\\oint_{{$1}}{$2}\\,\\mathrm{d}{$3}",
+        "small_latex":"\\oint_{{$1}}^{{$2}}d{$3}",
+	"asciimath":"oint_{{$1}}^{{$2}} d{$3}"},
+     "attrs":{
+	 "type":"loopintegral",
+	 "group":"calculus"},
+     "args":[
+	 {"down":"1","up":"2","small":"yes","name":"lower_limit"},
+	 {"down":"1","up":"2","delete":"3","name":"integrand"},
+	 {"down":"1","up":"2","bracket":"yes","delete":"4","name":"variable"}
      ]
     },
 

--- a/sym/symbols.json
+++ b/sym/symbols.json
@@ -82,6 +82,76 @@
 	 {"delete":"1"}]
     },
 
+    "dot":
+    {"output":{
+        "latex":"\\dot{$1}",
+        "asciimath":"dot {$1}"},
+     "attrs":{
+	 "type":"dot",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+    "dagger":
+    {"output":{
+        "latex":"{$1}\\dagger",
+        "asciimath":"{$1} dagger"},
+     "attrs":{
+	 "type":"dagger",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+
+    "underline":
+    {"output":{
+        "latex":"\\underline{$1}",
+        "asciimath":"underline {$1}"},
+     "attrs":{
+	 "type":"underline",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+    "hat":
+    {"output":{
+        "latex":"\\hat{$1}",
+        "asciimath":"hat {$1}"},
+     "attrs":{
+	 "type":"hat",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+    "tvec":
+    {"output":{
+        "latex":"\\vec{$1}",
+        "asciimath":"vec {$1}"},
+     "attrs":{
+	 "type":"vec",
+	 "group":"functions"},
+     "args":[
+	 {"delete":"1"}]
+    },
+
+    "ceil":
+    {"output":{
+        "latex":"\\lceil{$1}\\rceil",
+	"asciimath":"⌈{$1}⌉"},
+     "attrs":{
+	 "type":"bracket",
+	 "group":"functions"},
+     "ast":{
+	 "type":"pass"
+     },
+     "args":[
+	 {"delete":"1","is_bracket":"yes"}]
+    },
+
     "paren":
     {"output":{
         "latex":"\\left({$1}\\right)",


### PR DESCRIPTION
- [x] Create dot command \dot{ENTER_TEXT}
- [x] Create hat command \hat{ENTER_TEXT}
- [x] Create ceil command \lceil{ENTER_TEXT}\rceil
- [x] Create mathcal command \mathcal{ENTER_TEXT}
- [x] Create oint command similar to int command but with integral symbol replaced by oint symbol
- [x] Create prime command also aliased to ' key {ENTER_TEXT}\prime
- [x] Create dagger command {ENTER_TEXT}\dagger
- [x] Create text command \text{ENTER_TEXT}
- [x] Create underline command \underline{ENTER_TEXT}
- [x] Create bold command \mathbf{ENTER_TEXT}
- [x] Create tvec command \vec{ENTER_TEXT}

## Questions

1. Should we check the asciimath attribute. If so, how to check if asciimath is correct or not?
2. Please share the knowledge about the args attribute in symbols.json